### PR TITLE
Refactor the memtest module and add more memtests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "memtest"
 description = "A library for detecting faulty memory"
-version = "0.1.3"
+version = "0.2.0"
 authors = ["Brian Tsoi <brian.s.tsoi@gmail.com>"]
 edition = "2021"
 license = "MPL-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 [dependencies]
 anyhow = "1.0.69"
 num_cpus = "1.16.0"
-rand = "0.8.5"
+rand = {version = "0.8.5", features = ["small_rng"]}
 serde = {version = "1.0.214", features = ["derive"]}
 serde_json = "1.0.116"
 tracing = "0.1.37"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ mod memtest;
 mod prelude;
 
 pub use memtest::{
-    MemtestError, MemtestFailure, MemtestKind, MemtestOutcome, ParseMemtestKindError,
+    MemtestError, MemtestFailure, MemtestKind, MemtestOutcome, MemtestResult, ParseMemtestKindError,
 };
 
 #[derive(Debug)]
@@ -67,7 +67,7 @@ pub struct MemtestReportList {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct MemtestReport {
     pub test_kind: MemtestKind,
-    pub outcome: Result<MemtestOutcome, MemtestError<TimeoutError>>,
+    pub outcome: MemtestResult<TimeoutChecker>,
 }
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
@@ -92,7 +92,7 @@ struct MemLockGuard {
 
 /// A struct to ensure the test timeouts in a given duration
 #[derive(Debug)]
-struct TimeoutChecker {
+pub struct TimeoutChecker {
     deadline: Instant,
     state: Option<TimeoutCheckerState>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,27 +179,7 @@ impl MemtestRunner {
         let mut timed_out = false;
 
         for test_kind in &self.test_kinds {
-            let test = match test_kind {
-                MemtestKind::OwnAddressBasic => memtest::test_own_address_basic,
-                MemtestKind::OwnAddressRepeat => memtest::test_own_address_repeat,
-                MemtestKind::RandomVal => memtest::test_random_val,
-                MemtestKind::Xor => memtest::test_xor,
-                MemtestKind::Sub => memtest::test_sub,
-                MemtestKind::Mul => memtest::test_mul,
-                MemtestKind::Div => memtest::test_div,
-                MemtestKind::Or => memtest::test_or,
-                MemtestKind::And => memtest::test_and,
-                MemtestKind::SeqInc => memtest::test_seq_inc,
-                MemtestKind::SolidBits => memtest::test_solid_bits,
-                MemtestKind::Checkerboard => memtest::test_checkerboard,
-                MemtestKind::BlockSeq => memtest::test_block_seq,
-                MemtestKind::MovInvFixedBlock => memtest::test_mov_inv_fixed_block,
-                MemtestKind::MovInvFixedBit => memtest::test_mov_inv_fixed_bit,
-                MemtestKind::MovInvFixedRandom => memtest::test_mov_inv_fixed_random,
-                MemtestKind::MovInvWalk => memtest::test_mov_inv_walk,
-                MemtestKind::MovInvRandom => memtest::test_mov_inv_random,
-                MemtestKind::Modulo20 => memtest::test_modulo_20,
-            };
+            let test = test_kind.to_fn();
 
             let test_result = if timed_out {
                 Err(MemtestError::Observer(TimeoutError))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,6 +194,12 @@ impl MemtestRunner {
                 MemtestKind::SolidBits => memtest::test_solid_bits,
                 MemtestKind::Checkerboard => memtest::test_checkerboard,
                 MemtestKind::BlockSeq => memtest::test_block_seq,
+                MemtestKind::MovInvFixedBlock => memtest::test_mov_inv_fixed_block,
+                MemtestKind::MovInvFixedBit => memtest::test_mov_inv_fixed_bit,
+                MemtestKind::MovInvFixedRandom => memtest::test_mov_inv_fixed_random,
+                MemtestKind::MovInvWalk => memtest::test_mov_inv_walk,
+                MemtestKind::MovInvRandom => memtest::test_mov_inv_random,
+                MemtestKind::Modulo20 => memtest::test_modulo_20,
             };
 
             let test_result = if timed_out {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ pub struct MemtestReportList {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct MemtestReport {
     pub test_kind: MemtestKind,
-    pub outcome: MemtestResult<TimeoutChecker>,
+    pub outcome: Result<MemtestOutcome, MemtestError<TimeoutError>>,
 }
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
@@ -92,7 +92,7 @@ struct MemLockGuard {
 
 /// A struct to ensure the test timeouts in a given duration
 #[derive(Debug)]
-pub struct TimeoutChecker {
+struct TimeoutChecker {
     deadline: Instant,
     state: Option<TimeoutCheckerState>,
 }
@@ -326,10 +326,7 @@ impl MemtestReportList {
 }
 
 impl MemtestReport {
-    fn new(
-        test_kind: MemtestKind,
-        outcome: Result<MemtestOutcome, MemtestError<TimeoutError>>,
-    ) -> MemtestReport {
+    fn new(test_kind: MemtestKind, outcome: MemtestResult<TimeoutChecker>) -> MemtestReport {
         MemtestReport { test_kind, outcome }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,6 @@ use {
     std::{
         error::Error,
         fmt,
-        mem::size_of_val,
         time::{Duration, Instant},
     },
 };
@@ -153,7 +152,7 @@ impl MemtestRunner {
         // the memory region and try again
         let _working_set_resize_guard = if self.allow_working_set_resize {
             Some(
-                replace_set_size(size_of_val(memory))
+                replace_set_size(std::mem::size_of_val(memory))
                     .context("Failed to replace process working set size")?,
             )
         } else {

--- a/src/memtest.rs
+++ b/src/memtest.rs
@@ -191,10 +191,7 @@ pub fn test_own_address_repeat<O: TestObserver>(
 /// Split given memory into two halves and iterate through memory locations in pairs. For each
 /// pair, write a random value. After all locations are written, read and compare the two halves.
 #[tracing::instrument(skip_all)]
-pub fn test_random_val<O: TestObserver>(
-    memory: &mut [usize],
-    mut observer: O,
-) -> MemtestResult<O> {
+pub fn test_random_val<O: TestObserver>(memory: &mut [usize], mut observer: O) -> MemtestResult<O> {
     let (first_half, second_half) = split_slice_in_half(memory)?;
     let expected_iter =
         u64::try_from(first_half.len() * 2).context("Total number of iterations overflowed")?;
@@ -214,10 +211,7 @@ pub fn test_random_val<O: TestObserver>(
 /// memory locations in pairs. For each pair, write the XOR result of a random value and the value
 /// read from the location. After all locations are written, read and compare the two halves.
 #[tracing::instrument(skip_all)]
-pub fn test_xor<O: TestObserver>(
-    memory: &mut [usize],
-    observer: O,
-) -> MemtestResult<O> {
+pub fn test_xor<O: TestObserver>(memory: &mut [usize], observer: O) -> MemtestResult<O> {
     test_two_regions(memory, observer, std::ops::BitXor::bitxor)
 }
 
@@ -226,10 +220,7 @@ pub fn test_xor<O: TestObserver>(
 /// the value read from the location. After all locations are written, read and compare the two
 /// halves.
 #[tracing::instrument(skip_all)]
-pub fn test_sub<O: TestObserver>(
-    memory: &mut [usize],
-    observer: O,
-) -> MemtestResult<O> {
+pub fn test_sub<O: TestObserver>(memory: &mut [usize], observer: O) -> MemtestResult<O> {
     test_two_regions(memory, observer, usize::wrapping_sub)
 }
 
@@ -238,10 +229,7 @@ pub fn test_sub<O: TestObserver>(
 /// the value read from the location. After all locations are written, read and compare the two
 /// halves.
 #[tracing::instrument(skip_all)]
-pub fn test_mul<O: TestObserver>(
-    memory: &mut [usize],
-    observer: O,
-) -> MemtestResult<O> {
+pub fn test_mul<O: TestObserver>(memory: &mut [usize], observer: O) -> MemtestResult<O> {
     test_two_regions(memory, observer, usize::wrapping_mul)
 }
 
@@ -249,10 +237,7 @@ pub fn test_mul<O: TestObserver>(
 /// memory locations in pairs. For each pair, write the result of dividing the value read from the
 /// location with a random value. After all locations are written, read and compare the two halves.
 #[tracing::instrument(skip_all)]
-pub fn test_div<O: TestObserver>(
-    memory: &mut [usize],
-    observer: O,
-) -> MemtestResult<O> {
+pub fn test_div<O: TestObserver>(memory: &mut [usize], observer: O) -> MemtestResult<O> {
     test_two_regions(memory, observer, |n, d| n.wrapping_div(usize::max(d, 1)))
 }
 
@@ -260,10 +245,7 @@ pub fn test_div<O: TestObserver>(
 /// memory locations in pairs. For each pair, write the OR result of a random value and the value
 /// read from the location. After all locations are written, read and compare the two halves.
 #[tracing::instrument(skip_all)]
-pub fn test_or<O: TestObserver>(
-    memory: &mut [usize],
-    observer: O,
-) -> MemtestResult<O> {
+pub fn test_or<O: TestObserver>(memory: &mut [usize], observer: O) -> MemtestResult<O> {
     test_two_regions(memory, observer, std::ops::BitOr::bitor)
 }
 
@@ -271,10 +253,7 @@ pub fn test_or<O: TestObserver>(
 /// memory locations in pairs. For each pair, write the AND result of a random value and the value
 /// read from the location. After all locations are written, read and compare the two halves.
 #[tracing::instrument(skip_all)]
-pub fn test_and<O: TestObserver>(
-    memory: &mut [usize],
-    observer: O,
-) -> MemtestResult<O> {
+pub fn test_and<O: TestObserver>(memory: &mut [usize], observer: O) -> MemtestResult<O> {
     test_two_regions(memory, observer, std::ops::BitAnd::bitand)
 }
 
@@ -315,10 +294,7 @@ fn test_two_regions<O: TestObserver>(
 /// random value at the start. For each pair, write the result of adding the random value and the
 /// index of iteration. After all locations are written, read and compare the two halves.
 #[tracing::instrument(skip_all)]
-pub fn test_seq_inc<O: TestObserver>(
-    memory: &mut [usize],
-    mut observer: O,
-) -> MemtestResult<O> {
+pub fn test_seq_inc<O: TestObserver>(memory: &mut [usize], mut observer: O) -> MemtestResult<O> {
     let (first_half, second_half) = split_slice_in_half(memory)?;
     let expected_iter =
         u64::try_from(first_half.len() * 2).context("Total number of iterations overflowed")?;
@@ -340,10 +316,7 @@ pub fn test_seq_inc<O: TestObserver>(
 /// After all locations are written, read and compare the two halves.
 /// This procedure is repeated 64 times.
 #[tracing::instrument(skip_all)]
-pub fn test_solid_bits<O: TestObserver>(
-    memory: &mut [usize],
-    mut observer: O,
-) -> MemtestResult<O> {
+pub fn test_solid_bits<O: TestObserver>(memory: &mut [usize], mut observer: O) -> MemtestResult<O> {
     const NUM_RUNS: u64 = 64;
     let (first_half, second_half) = split_slice_in_half(memory)?;
     let expected_iter = u64::try_from(first_half.len() * 2)
@@ -414,10 +387,7 @@ pub fn test_checkerboard<O: TestObserver>(
 /// halves.
 /// This procedure is repeated 256 times, with i corresponding to the iteration number 0-255.
 #[tracing::instrument(skip_all)]
-pub fn test_block_seq<O: TestObserver>(
-    memory: &mut [usize],
-    mut observer: O,
-) -> MemtestResult<O> {
+pub fn test_block_seq<O: TestObserver>(memory: &mut [usize], mut observer: O) -> MemtestResult<O> {
     const NUM_RUNS: u64 = 256;
     let (first_half, second_half) = split_slice_in_half(memory)?;
     let expected_iter = u64::try_from(first_half.len() * 2)
@@ -755,10 +725,7 @@ pub fn test_mov_inv_random<O: TestObserver>(
 /// stored in every 20th location is unchanged.
 /// The procedure is repeated with offsets 0-19 to test all memory locations.
 #[tracing::instrument(skip_all)]
-pub fn test_modulo_20<O: TestObserver>(
-    memory: &mut [usize],
-    mut observer: O,
-) -> MemtestResult<O> {
+pub fn test_modulo_20<O: TestObserver>(memory: &mut [usize], mut observer: O) -> MemtestResult<O> {
     const STEP: usize = 20;
     (memory.len() > STEP)
         .then_some(())

--- a/src/memtest.rs
+++ b/src/memtest.rs
@@ -867,9 +867,9 @@ impl fmt::Debug for MemtestFailure {
                 actual,
             } => f
                 .debug_struct("UnexpectedValue")
-                .field("address", &format_args!("0x{:x}", address))
-                .field("expected", &format_args!("0x{:x}", expected))
-                .field("actual", &format_args!("0x{:x}", actual))
+                .field("address", &format_args!("0x{address:x}"))
+                .field("expected", &format_args!("0x{expected:x}"))
+                .field("actual", &format_args!("0x{actual:x}"))
                 .finish(),
             Self::MismatchedValues {
                 address1,
@@ -878,10 +878,10 @@ impl fmt::Debug for MemtestFailure {
                 value2,
             } => f
                 .debug_struct("MismatchedValues")
-                .field("address1", &format_args!("0x{:x}", address1))
-                .field("value1", &format_args!("0x{:x}", value1))
-                .field("address2", &format_args!("0x{:x}", address2))
-                .field("value2", &format_args!("0x{:x}", value2))
+                .field("address1", &format_args!("0x{address1:x}"))
+                .field("value1", &format_args!("0x{value1:x}"))
+                .field("address2", &format_args!("0x{address2:x}"))
+                .field("value2", &format_args!("0x{value2:x}"))
                 .finish(),
         }
     }

--- a/src/memtest.rs
+++ b/src/memtest.rs
@@ -684,7 +684,7 @@ pub fn test_mov_inv_random<O: TestObserver>(
     };
     let expected_iter = u64::try_from(memory.len())
         .ok()
-        .and_then(|count| count.checked_mul(MOV_INV_ITERATIONS * 2))
+        .and_then(|count| count.checked_mul(MOV_INV_ITERATIONS))
         .context("Total number of iterations overflowed")?;
     observer.init(expected_iter);
     let seed = {

--- a/src/memtest.rs
+++ b/src/memtest.rs
@@ -6,7 +6,8 @@ use {
 };
 
 // TODO: Intend to convert this module to a standalone `no_std` crate
-// TODO: TimeoutChecker will be a trait instead
+
+pub type MemtestResult<O> = Result<MemtestOutcome, MemtestError<<O as TestObserver>::Error>>;
 
 #[derive(Debug, Serialize, Deserialize)]
 #[must_use]
@@ -107,7 +108,7 @@ pub struct ParseMemtestKindError;
 pub fn test_own_address_basic<O: TestObserver>(
     memory: &mut [usize],
     mut observer: O,
-) -> Result<MemtestOutcome, MemtestError<O::Error>> {
+) -> MemtestResult<O> {
     let expected_iter = u64::try_from(memory.len())
         .ok()
         .and_then(|count| count.checked_mul(2))
@@ -144,7 +145,7 @@ pub fn test_own_address_basic<O: TestObserver>(
 pub fn test_own_address_repeat<O: TestObserver>(
     memory: &mut [usize],
     mut observer: O,
-) -> Result<MemtestOutcome, MemtestError<O::Error>> {
+) -> MemtestResult<O> {
     const NUM_RUNS: u64 = 16;
     let expected_iter = u64::try_from(memory.len())
         .ok()
@@ -193,7 +194,7 @@ pub fn test_own_address_repeat<O: TestObserver>(
 pub fn test_random_val<O: TestObserver>(
     memory: &mut [usize],
     mut observer: O,
-) -> Result<MemtestOutcome, MemtestError<O::Error>> {
+) -> MemtestResult<O> {
     let (first_half, second_half) = split_slice_in_half(memory)?;
     let expected_iter =
         u64::try_from(first_half.len() * 2).context("Total number of iterations overflowed")?;
@@ -216,7 +217,7 @@ pub fn test_random_val<O: TestObserver>(
 pub fn test_xor<O: TestObserver>(
     memory: &mut [usize],
     observer: O,
-) -> Result<MemtestOutcome, MemtestError<O::Error>> {
+) -> MemtestResult<O> {
     test_two_regions(memory, observer, std::ops::BitXor::bitxor)
 }
 
@@ -228,7 +229,7 @@ pub fn test_xor<O: TestObserver>(
 pub fn test_sub<O: TestObserver>(
     memory: &mut [usize],
     observer: O,
-) -> Result<MemtestOutcome, MemtestError<O::Error>> {
+) -> MemtestResult<O> {
     test_two_regions(memory, observer, usize::wrapping_sub)
 }
 
@@ -240,7 +241,7 @@ pub fn test_sub<O: TestObserver>(
 pub fn test_mul<O: TestObserver>(
     memory: &mut [usize],
     observer: O,
-) -> Result<MemtestOutcome, MemtestError<O::Error>> {
+) -> MemtestResult<O> {
     test_two_regions(memory, observer, usize::wrapping_mul)
 }
 
@@ -251,7 +252,7 @@ pub fn test_mul<O: TestObserver>(
 pub fn test_div<O: TestObserver>(
     memory: &mut [usize],
     observer: O,
-) -> Result<MemtestOutcome, MemtestError<O::Error>> {
+) -> MemtestResult<O> {
     test_two_regions(memory, observer, |n, d| n.wrapping_div(usize::max(d, 1)))
 }
 
@@ -262,7 +263,7 @@ pub fn test_div<O: TestObserver>(
 pub fn test_or<O: TestObserver>(
     memory: &mut [usize],
     observer: O,
-) -> Result<MemtestOutcome, MemtestError<O::Error>> {
+) -> MemtestResult<O> {
     test_two_regions(memory, observer, std::ops::BitOr::bitor)
 }
 
@@ -273,7 +274,7 @@ pub fn test_or<O: TestObserver>(
 pub fn test_and<O: TestObserver>(
     memory: &mut [usize],
     observer: O,
-) -> Result<MemtestOutcome, MemtestError<O::Error>> {
+) -> MemtestResult<O> {
     test_two_regions(memory, observer, std::ops::BitAnd::bitand)
 }
 
@@ -286,7 +287,7 @@ fn test_two_regions<O: TestObserver>(
     memory: &mut [usize],
     mut observer: O,
     transform_fn: fn(usize, usize) -> usize,
-) -> Result<MemtestOutcome, MemtestError<O::Error>> {
+) -> MemtestResult<O> {
     mem_reset(memory);
     let (first_half, second_half) = split_slice_in_half(memory)?;
     let expected_iter =
@@ -317,7 +318,7 @@ fn test_two_regions<O: TestObserver>(
 pub fn test_seq_inc<O: TestObserver>(
     memory: &mut [usize],
     mut observer: O,
-) -> Result<MemtestOutcome, MemtestError<O::Error>> {
+) -> MemtestResult<O> {
     let (first_half, second_half) = split_slice_in_half(memory)?;
     let expected_iter =
         u64::try_from(first_half.len() * 2).context("Total number of iterations overflowed")?;
@@ -342,7 +343,7 @@ pub fn test_seq_inc<O: TestObserver>(
 pub fn test_solid_bits<O: TestObserver>(
     memory: &mut [usize],
     mut observer: O,
-) -> Result<MemtestOutcome, MemtestError<O::Error>> {
+) -> MemtestResult<O> {
     const NUM_RUNS: u64 = 64;
     let (first_half, second_half) = split_slice_in_half(memory)?;
     let expected_iter = u64::try_from(first_half.len() * 2)
@@ -379,7 +380,7 @@ pub fn test_solid_bits<O: TestObserver>(
 pub fn test_checkerboard<O: TestObserver>(
     memory: &mut [usize],
     mut observer: O,
-) -> Result<MemtestOutcome, MemtestError<O::Error>> {
+) -> MemtestResult<O> {
     const NUM_RUNS: u64 = 64;
     let (first_half, second_half) = split_slice_in_half(memory)?;
     let expected_iter = u64::try_from(first_half.len() * 2)
@@ -416,7 +417,7 @@ pub fn test_checkerboard<O: TestObserver>(
 pub fn test_block_seq<O: TestObserver>(
     memory: &mut [usize],
     mut observer: O,
-) -> Result<MemtestOutcome, MemtestError<O::Error>> {
+) -> MemtestResult<O> {
     const NUM_RUNS: u64 = 256;
     let (first_half, second_half) = split_slice_in_half(memory)?;
     let expected_iter = u64::try_from(first_half.len() * 2)
@@ -466,7 +467,7 @@ const MOV_INV_ITERATIONS: u64 = 3;
 pub fn test_mov_inv_fixed_block<O: TestObserver>(
     memory: &mut [usize],
     mut observer: O,
-) -> Result<MemtestOutcome, MemtestError<O::Error>> {
+) -> MemtestResult<O> {
     let expected_iter = u64::try_from(memory.len())
         .ok()
         .and_then(|count| count.checked_mul(MOV_INV_ITERATIONS * 2))
@@ -491,7 +492,7 @@ pub fn test_mov_inv_fixed_block<O: TestObserver>(
 pub fn test_mov_inv_fixed_bit<O: TestObserver>(
     memory: &mut [usize],
     mut observer: O,
-) -> Result<MemtestOutcome, MemtestError<O::Error>> {
+) -> MemtestResult<O> {
     const NUM_RUNS: u64 = 8;
     let expected_iter = u64::try_from(memory.len())
         .ok()
@@ -522,7 +523,7 @@ pub fn test_mov_inv_fixed_bit<O: TestObserver>(
 pub fn test_mov_inv_fixed_random<O: TestObserver>(
     memory: &mut [usize],
     mut observer: O,
-) -> Result<MemtestOutcome, MemtestError<O::Error>> {
+) -> MemtestResult<O> {
     let expected_iter = u64::try_from(memory.len())
         .ok()
         .and_then(|count| count.checked_mul(MOV_INV_ITERATIONS * 2))
@@ -540,7 +541,7 @@ fn mov_inv_fixed_pattern<O: TestObserver>(
     memory: &mut [usize],
     pattern: usize,
     observer: &mut O,
-) -> Result<MemtestOutcome, MemtestError<O::Error>> {
+) -> MemtestResult<O> {
     for mem_ref in memory.iter_mut() {
         observer.check().map_err(|e| MemtestError::Observer(e))?;
         write_volatile_safe(mem_ref, pattern);
@@ -597,7 +598,7 @@ fn mov_inv_fixed_pattern<O: TestObserver>(
 pub fn test_mov_inv_walk<O: TestObserver>(
     memory: &mut [usize],
     mut observer: O,
-) -> Result<MemtestOutcome, MemtestError<O::Error>> {
+) -> MemtestResult<O> {
     const NUM_RUNS: usize = size_of::<usize>();
     let num_runs_u64 = u64::try_from(NUM_RUNS).unwrap();
     let expected_iter = u64::try_from(memory.len())
@@ -623,7 +624,7 @@ fn mov_inv_walking_pattern<O: TestObserver>(
     memory: &mut [usize],
     starting_pattern: usize,
     observer: &mut O,
-) -> Result<MemtestOutcome, MemtestError<O::Error>> {
+) -> MemtestResult<O> {
     let mut pattern = starting_pattern;
     for mem_ref in memory.iter_mut() {
         observer.check().map_err(|e| MemtestError::Observer(e))?;
@@ -681,7 +682,7 @@ fn mov_inv_walking_pattern<O: TestObserver>(
 pub fn test_mov_inv_random<O: TestObserver>(
     memory: &mut [usize],
     mut observer: O,
-) -> Result<MemtestOutcome, MemtestError<O::Error>> {
+) -> MemtestResult<O> {
     use {
         rand::{rngs::SmallRng, Rng, SeedableRng},
         std::time::Instant,
@@ -757,7 +758,7 @@ pub fn test_mov_inv_random<O: TestObserver>(
 pub fn test_modulo_20<O: TestObserver>(
     memory: &mut [usize],
     mut observer: O,
-) -> Result<MemtestOutcome, MemtestError<O::Error>> {
+) -> MemtestResult<O> {
     const STEP: usize = 20;
     (memory.len() > STEP)
         .then_some(())
@@ -842,7 +843,7 @@ fn compare_regions<O: TestObserver>(
     region1: &mut [usize],
     region2: &mut [usize],
     observer: &mut O,
-) -> Result<MemtestOutcome, MemtestError<O::Error>> {
+) -> MemtestResult<O> {
     for (ref1, ref2) in region1.iter().zip(region2.iter()) {
         observer.check().map_err(|e| MemtestError::Observer(e))?;
 


### PR DESCRIPTION
Refactor by adding the `TestObserver` trait and `MemtestResult` type alias.
Also added ~~6~~ 7 new memtests adapted from [Memtest86+](https://github.com/memtest86plus/memtest86plus).