### PR TITLE
Refactor to compile with Rust 1.76

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "memtest"
 description = "A library for detecting faulty memory"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Brian Tsoi <brian.s.tsoi@gmail.com>"]
 edition = "2021"
 license = "MPL-2.0"

--- a/src/memtest.rs
+++ b/src/memtest.rs
@@ -52,7 +52,7 @@ macro_rules! memtest_kinds {{
     }
 
     impl MemtestKind {
-        pub const ALL: &[Self] = &[
+        pub const ALL: &'static [Self] = &[
             $(Self::$variant),*
         ];
     }


### PR DESCRIPTION
As mentioned by [this comment](https://bugzilla.mozilla.org/show_bug.cgi?id=1565033#c12) while trying to integrate memtesting into the Firefox crash reporter client, Rust 1.82 is not ready in Firefox yet. 

This PR adds minor changes so that the crate works with Rust 1.76.