### PR TITLE
 Implement more descriptive TimeoutError Serialization and Deserialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "memtest"
 description = "A library for detecting faulty memory"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Brian Tsoi <brian.s.tsoi@gmail.com>"]
 edition = "2021"
 license = "MPL-2.0"


### PR DESCRIPTION
Due to the addition of `TestObserver`, `TimeoutError` is serialized to `null` as it is an empty struct rather than an enum variant.
For example,
```
  {
      "test_kind": "SolidBits",
      "outcome": {
        "Err": {
          "Observer": null
        }
      }
  }
```
Instead, it would be preferrable to be explicit with the error
```
  {
      "test_kind": "SolidBits",
      "outcome": {
        "Err": {
          "Observer": "TimeoutError"
        }
      }
  }
```

This is helpful for example when we show the json string in the crash annotations of Firefox.