### PR TITLE
Fix SmallRng seed compilation issue on 32-bit machines

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "memtest"
 description = "A library for detecting faulty memory"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Brian Tsoi <brian.s.tsoi@gmail.com>"]
 edition = "2021"
 license = "MPL-2.0"


### PR DESCRIPTION
`SmallRng::from_seed()` expects different sizes of arrays of `u8` depending on architecture. Change to `SmallRng::seed_from_u64()` to work across architectures.