### PR TITLE
Refactor memtest.rs

### DIFF
--- a/src/memtest.rs
+++ b/src/memtest.rs
@@ -1429,7 +1429,7 @@ pub fn test_modulo_20<O: TestObserver>(memory: &mut [usize], mut observer: O) ->
             observer.check().map_err(MemtestError::Observer)?;
 
             if let Err(f) = assert_expected_value(
-                address_from_ref(memref),
+                address_from_ref(mem_ref),
                 pattern,
                 read_volatile_safe(mem_ref),
             ) {


### PR DESCRIPTION
Refactor the memtests as they have similar structure that could be expressed more concisely through the `TestAlgorithm` trait, as suggested by cmartin.

A few additional notes:
* A `mov_inv` module with the `MovInv` trait is also introduced to generalize most of the moving inversion test algorithms.
* Note that due to its unique structure, the `BlockMove` test cannot be refactored in a similar manner. Meanwhile, the `Modulo20` test could technically be refactored to fit the `TestAlgorithm` trait, but it would lead to many unnecessary calls to `observer.check()`, so I also plan to keep it as is.
* This PR is still WIP. There needs to be another trait for 2-region tests, and it is planned to rename structs to avoid using the `Memtest` prefix. 
* Previous implementations of various memtests are kept in the file for now for easy reference, they will be removed once the rest of the PR is ready.